### PR TITLE
Bump falafel to remove git esprima-dev sub dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "browjadify-compile": "^0.1.0",
     "escodegen": "0.0.22",
-    "falafel": "~0.2.1",
+    "falafel": "^1.2.0",
     "through": "~2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Only done the minimum bump required. Gets rid of the nasty `substack/esprima#is-keyword` dependency that can cause issues when shrinkwrapping.

Tests all still passing